### PR TITLE
Hot_fix/[LJI-48] total_limit from deactivate plan also calulated

### DIFF
--- a/src/main/java/com/coherentsolutions/pot/insurance/repository/PlanRepository.java
+++ b/src/main/java/com/coherentsolutions/pot/insurance/repository/PlanRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import com.coherentsolutions.pot.insurance.constants.PlanStatus;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -17,6 +18,6 @@ public interface PlanRepository extends JpaRepository<PlanEntity, UUID>,
 
   Optional<PlanEntity> findById(UUID id);
 
-  @Query("SELECT COALESCE(SUM(p.totalLimit), 0) FROM PlanEntity p WHERE p.packageEntity.id = :packageId")
-  double findSumOfTotalLimitByPackageId(UUID packageId);
+  @Query("SELECT COALESCE(SUM(p.totalLimit), 0) FROM PlanEntity p WHERE p.packageEntity.id = :packageId AND p.status = :status")
+  double findSumOfTotalLimitByPackageId(UUID packageId, PlanStatus status);
 }

--- a/src/main/java/com/coherentsolutions/pot/insurance/service/PlanService.java
+++ b/src/main/java/com/coherentsolutions/pot/insurance/service/PlanService.java
@@ -108,7 +108,7 @@ public class PlanService {
   private void validateContributionLimit(PlanEntity planEntity) {
     UUID packageId = planEntity.getPackageEntity().getId();
     double totalContributions =
-        planRepository.findSumOfTotalLimitByPackageId(packageId);
+        planRepository.findSumOfTotalLimitByPackageId(packageId, PlanStatus.ACTIVE);
     PackageEntity packageEntity = packageRepository.findById(packageId)
             .orElseThrow(() -> new NotFoundException("Package with id " + packageId + " not found"));
     double remainingContribution = packageEntity.getContributions() - totalContributions;

--- a/src/test/java/com/coherentsolutions/pot/insurance/plan/PlanServiceTest.java
+++ b/src/test/java/com/coherentsolutions/pot/insurance/plan/PlanServiceTest.java
@@ -174,7 +174,7 @@ class PlanServiceTest {
     packageEntity.setId(packageId);
     packageEntity.setContributions(1000);
 
-    when(planRepository.findSumOfTotalLimitByPackageId(packageId)).thenReturn(500.0);
+    when(planRepository.findSumOfTotalLimitByPackageId(packageId, PlanStatus.ACTIVE)).thenReturn(500.0);
     when(packageRepository.findById(packageId)).thenReturn(Optional.of(packageEntity));
     when(planRepository.save(any(PlanEntity.class))).thenReturn(planEntity);
 
@@ -197,7 +197,7 @@ class PlanServiceTest {
     packageEntity.setId(packageId);
     packageEntity.setContributions(1000);
 
-    when(planRepository.findSumOfTotalLimitByPackageId(packageId)).thenReturn(500.0);
+    when(planRepository.findSumOfTotalLimitByPackageId(packageId, PlanStatus.ACTIVE)).thenReturn(500.0);
     when(packageRepository.findById(packageId)).thenReturn(Optional.of(packageEntity));
 
     assertThrows(IllegalStateException.class, () -> planService.addPlan(planDTO));


### PR DESCRIPTION
Now total_limit from deactivated plan is not added to the total_limit sum when we try to create a new plan.